### PR TITLE
Added pod env vars, image pull secrets and some field values

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -42,6 +42,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
 | `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |
 | `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |
+| `Master.BuildInfoProxyPort`       | Open a port, for Artifactory plugin  | Not set                                                                      |
 | `Master.CustomConfigMap`          | Use a custom ConfigMap               | `false`                                                                      |
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
@@ -56,16 +57,20 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 
 ### Jenkins Agent
 
-| Parameter               | Description                                     | Default                |
-| ----------------------- | ----------------------------------------------- | ---------------------- |
-| `Agent.AlwaysPullImage` | Always pull agent container image before build  | `false`                |
-| `Agent.Enabled`         | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
-| `Agent.Image`           | Agent image name                                | `jenkinsci/jnlp-slave` |
-| `Agent.ImageTag`        | Agent image tag                                 | `2.62`                 |
-| `Agent.Privileged`      | Agent privileged container                      | `false`                |
-| `Agent.Cpu`             | Agent requested cpu                             | `200m`                 |
-| `Agent.Memory`          | Agent requested memory                          | `256Mi`                |
-| `Agent.volumes`         | Additional volumes                              | `nil`                  |
+| Parameter                     | Description                                     | Default                |
+| ----------------------------- | ----------------------------------------------- | ---------------------- |
+| `Agent.AlwaysPullImage`       | Always pull agent container image before build  | `false`                |
+| `Agent.Enabled`               | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
+| `Agent.Image`                 | Agent image name                                | `jenkinsci/jnlp-slave` |
+| `Agent.ImageTag`              | Agent image tag                                 | `2.62`                 |
+| `Agent.Privileged`            | Agent privileged container                      | `false`                |
+| `Agent.Cpu`                   | Agent requested cpu                             | `200m`                 |
+| `Agent.Memory`                | Agent requested memory                          | `256Mi`                |
+| `Agent.RetentionTimeout`      | Time until slave pod is recycled (minutes)      | `5`                    |
+| `Agent.ConnectAndReadTimeout` | Time for getting in contact with a slave (sec)  | `0`                    |
+| `Agent.envVars`               | Additional environment variables                | `nil`                  |
+| `Agent.imagePullSecrets`      | Image pull secrets for private Docker repos     | `nil`                  |
+| `Agent.volumes`               | Additional volumes                              | `nil`                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -26,13 +26,14 @@ data:
       <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
       <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
       <clouds>
-        <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@0.11">
+        <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@0.12">
           <name>kubernetes</name>
           <templates>
 {{- if .Values.Agent.Enabled }}
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
               <inheritFrom></inheritFrom>
               <name>default</name>
+              <namespace>{{ .Release.Namespace }}</namespace>
               <instanceCap>2147483647</instanceCap>
               <idleMinutes>0</idleMinutes>
               <label>{{.Release.Name}}-{{.Values.Agent.Component}}</label>
@@ -68,8 +69,23 @@ data:
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               </containers>
               <envVars/>
+{{- range $index, $var := .Values.Agent.envVars }}
+                <org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
+                  <key>{{ $var.name }}</key>
+                  <value>{{ $var.value }}</value>
+                </org.csanchez.jenkins.plugins.kubernetes.PodEnvVar>
+{{- end }}
               <annotations/>
-              <imagePullSecrets/>
+              <imagePullSecrets>
+{{- range $index, $secret := .Values.Agent.imagePullSecrets }}
+                <org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+                  <name>{{ $secret.name }}</name>
+{{- range $key, $value := $secret }}{{- if not (eq $key "name") }}
+                  <{{ $key }}>{{ $value }}</{{ $key }}>
+{{- end }}{{- end }}
+                </org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+{{- end }}
+              </imagePullSecrets>
               <nodeProperties/>
             </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
 {{- end -}}
@@ -80,9 +96,10 @@ data:
           <jenkinsUrl>http://{{ template "fullname" . }}:{{.Values.Master.ServicePort}}</jenkinsUrl>
           <jenkinsTunnel>{{ template "fullname" . }}-agent:50000</jenkinsTunnel>
           <containerCap>10</containerCap>
-          <retentionTimeout>5</retentionTimeout>
-          <connectTimeout>0</connectTimeout>
-          <readTimeout>0</readTimeout>
+          <retentionTimeout>{{default 5 .Values.Agent.RetentionTimeout}}</retentionTimeout>
+          <connectTimeout>{{default 0 .Values.Agent.ConnectAndReadTimeout}}</connectTimeout>
+          <readTimeout>{{default 0 .Values.Agent.ConnectAndReadTimeout}}</readTimeout>
+          <defaultsProviderTemplate>default</defaultsProviderTemplate>
         </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
       </clouds>
       <quietPeriod>5</quietPeriod>

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -92,6 +92,10 @@ spec:
             - containerPort: {{ .Values.Master.JMXPort }}
               name: jmx
             {{- end }}
+            {{- if .Values.Master.BuildInfoProxyPort }}
+            - containerPort: {{ .Values.Master.BuildInfoProxyPort }}
+              name: arm-proxy
+            {{- end }}
           resources:
             requests:
               cpu: "{{.Values.Master.Cpu}}"

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -37,6 +37,8 @@ Master:
 #   -Dcom.sun.management.jmxremote.authenticate=false 
 #   -Dcom.sun.management.jmxremote.ssl=false 
 # JMXPort: 4000
+# Optionally configure a BuildInfoProxy port for artifactory plugin
+# BuildInfoProxyPort: 9000
 # List of plugins to be install during Jenkins master start
   InstallPlugins:
       - kubernetes:0.11 
@@ -79,6 +81,20 @@ Agent:
   Memory: "256Mi"
   # You may want to change this to true while testing a new image
   AlwaysPullImage: false
+  # Time in minutes after which Jenkins kills the slaves. Defaults to 5min.
+  # For long-running jobs like building Docker images etc. 15min or more is recommendable.
+  # RetentionTimeout: 5
+  # Time in seconds to wait for a slave pod to reach the master. Defaults to 0.
+  # In our experience, if you don't set it to 100 or so slave pods never start.
+  # ConnectAndReadTimeout: 100
+  # Image pull secrets to use when pulling from private Docker registries.
+  # The secrets must be created in Jenkins by some other means.
+  imagePullSecrets:
+  # - name: my-secret
+  # Define environment variables as a list of name,value pairs
+  envVars:
+  # - name: FOO
+  #   value: bar
   # You can define the volumes that you want to mount for this container
   # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
   # Configure the attributes as they appear in the corresponding Java class for that type


### PR DESCRIPTION
Added the ability to define pod environment variables in helm chart values (Values->Agent->envVars)
Added the ability to define image pull secrets (Values->Agent->imagePullSecrets)
Added the ability to set retention time-out and connect/read time-outs
Upgraded plugin version (1.11->1.12)
Fixed pod template namespace and default provider template values